### PR TITLE
Extended GoldHandler functionality with a loseGold-method.

### DIFF
--- a/core/src/com/tda367/game/Model/Goldhandler.java
+++ b/core/src/com/tda367/game/Model/Goldhandler.java
@@ -8,8 +8,11 @@ public class Goldhandler extends MainHandler {
     // If isn't it will give it to the next handler.
     public void handleRequest(Request request){
 
-        if (request.getDescription() == HandlerItemDefiners.GOLD) {
+        if (request.getDescription() == HandlerItemDefiners.ADDGOLD) {
             addGold(request.getValue());
+        }
+        if (request.getDescription() == HandlerItemDefiners.LOSEGOLD) {
+            loseGold(request.getValue());
         }
         else if (m_successor != null)
         {
@@ -20,6 +23,11 @@ public class Goldhandler extends MainHandler {
     // Adds gold to the total
     private void addGold(int amount){
         this.gold+=amount;
+    }
+
+    // Adds gold to the total
+    private void loseGold(int amount){
+        this.gold-=amount;
     }
 
     // Returns gold

--- a/core/src/com/tda367/game/Model/HandlerItemDefiners.java
+++ b/core/src/com/tda367/game/Model/HandlerItemDefiners.java
@@ -2,5 +2,5 @@ package Model;
 
 // For the request description to evaluate if it is the correct handler.
 public enum HandlerItemDefiners {
-    GOLD, POINTS
+    ADDGOLD, LOSEGOLD, POINTS
 }

--- a/core/src/com/tda367/game/Model/Tower.java
+++ b/core/src/com/tda367/game/Model/Tower.java
@@ -43,6 +43,7 @@ public class Tower implements IBuild, IUpgradeable, IObservers {
         }
         else if (gold.getGold() >= 1000){
             turrets.add(turret);
+            gold.handleRequest(new Request(HandlerItemDefiners.LOSEGOLD, 1000));
         }
         else{
             System.out.println("Not enough gold");
@@ -55,6 +56,7 @@ public class Tower implements IBuild, IUpgradeable, IObservers {
     public void upgradeTurret(int index){
         if(gold.getGold() >=1000){
             getTurrets().get(index).upgrade();
+            gold.handleRequest(new Request(HandlerItemDefiners.LOSEGOLD, 1000));
             System.out.println("Turret Upgraded");
         }
         else{
@@ -68,6 +70,7 @@ public class Tower implements IBuild, IUpgradeable, IObservers {
     public void sellTurret(Turret turret){
         if (this.turrets.contains(turret)){
             this.turrets.remove(turret);
+            gold.handleRequest(new Request(HandlerItemDefiners.ADDGOLD, 500));
         }
         else{
             throw new IllegalStateException("You don't have any turrets to be sold");
@@ -83,6 +86,7 @@ public class Tower implements IBuild, IUpgradeable, IObservers {
             this.incrementLevel();
             this.incrementHealth();
             this.incrementMaxCapacity();
+            gold.handleRequest(new Request(HandlerItemDefiners.LOSEGOLD, 3000));
         }
         else{
             System.out.println("Not enough gold");

--- a/core/src/test/java/TowerJUnitTest.java
+++ b/core/src/test/java/TowerJUnitTest.java
@@ -32,7 +32,7 @@ public class TowerJUnitTest {
     @Test
     public void testTowerContainsSpecifiedTurret() {
         Goldhandler gold = new Goldhandler();
-        gold.handleRequest(new Request(HandlerItemDefiners.GOLD, 1000));
+        gold.handleRequest(new Request(HandlerItemDefiners.ADDGOLD, 1000));
         Tower tower3 = new Tower(gold);
         Turret turret1 = new Turret();
         tower3.buildTurret(turret1);
@@ -42,7 +42,7 @@ public class TowerJUnitTest {
     @Test
     public void testTowerUpgrades(){
         Goldhandler gold2 = new Goldhandler();
-        gold2.handleRequest(new Request(HandlerItemDefiners.GOLD, 3000));
+        gold2.handleRequest(new Request(HandlerItemDefiners.ADDGOLD, 3000));
         Tower tower4 = new Tower(gold2);
         tower4.upgrade();
         Turret turret1 = new Turret();
@@ -56,7 +56,7 @@ public class TowerJUnitTest {
     @Test
     public void testTowerUpgradesTurret(){
         Goldhandler gold3 = new Goldhandler();
-        gold3.handleRequest(new Request(HandlerItemDefiners.GOLD, 7000));
+        gold3.handleRequest(new Request(HandlerItemDefiners.ADDGOLD, 7000));
         Tower tower4 = new Tower(gold3);
         tower4.upgrade();
         Turret turret1 = new Turret();

--- a/core/src/test/java/UiJunitTest.java
+++ b/core/src/test/java/UiJunitTest.java
@@ -15,7 +15,7 @@ public class UiJunitTest {
     @Test
     public void addOneHundredGolds(){
         Goldhandler h1 = new Goldhandler();
-        h1.handleRequest(new Request(HandlerItemDefiners.GOLD, 100));
+        h1.handleRequest(new Request(HandlerItemDefiners.ADDGOLD, 100));
         assertSame(100, h1.getGold(), "should be the same");
     }
 


### PR DESCRIPTION
ENUMs that GoldHandler uses are now ADDGOLD and LOSEGOLD. 
Name-refactor in classes that used GOLD->ADDGOLD.
loseGold now used in Tower after it upgrades.